### PR TITLE
Fix typo in README.md: percent_packets_loss -> percent_packet_loss

### DIFF
--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -48,7 +48,7 @@ apt-get install iputils-ping
   - fields:
     - packets_transmitted (integer)
     - packets_received (integer)
-    - percent_packets_loss (float)
+    - percent_packet_loss (float)
     - average_response_ms (integer)
     - minimum_response_ms (integer)
     - maximum_response_ms (integer)


### PR DESCRIPTION
The example data and the code refer to percent_packet_loss in singular but the documentation mentions percent_packets_loss in plural. Fix README.md.

If merging this requires some hoops, please just fix directly whoever has the power to do so.

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
